### PR TITLE
Add optional --debug argument

### DIFF
--- a/sketchlogic/parser.py
+++ b/sketchlogic/parser.py
@@ -23,6 +23,12 @@ def parse_args() -> argparse.Namespace:
         type=_file_path,
         help="path to the output JSON file",
     )
+    parser.add_argument(
+        "--debug",
+        action="store_true",
+        default =False,
+        help="enable debug mode",
+    )
 
     return parser.parse_args()
 


### PR DESCRIPTION
Fixes #46

Added the optional --debug boolean argument in sketchlogic/parser.py.

Default value is False.
No other files were modified.