### PR TITLE
add --target optional argument with default iris

### DIFF
--- a/sketchlogic/parser.py
+++ b/sketchlogic/parser.py
@@ -32,7 +32,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--target",
         default="iris",
-        help="target model",
+        help="target simulation software",
     )
 
     return parser.parse_args()

--- a/sketchlogic/parser.py
+++ b/sketchlogic/parser.py
@@ -29,6 +29,11 @@ def parse_args() -> argparse.Namespace:
         default =False,
         help="enable debug mode",
     )
+    parser.add_argument(
+        "--target",
+        default="iris",
+        help="target model",
+    )
 
     return parser.parse_args()
 


### PR DESCRIPTION
Fixes #44

Added the optional --target argument in sketchlogic/parser.py.

Default value is "iris".
No other files were modified.