### PR TITLE
Enh: add debug from args flag

### DIFF
--- a/sketchlogic/__main__.py
+++ b/sketchlogic/__main__.py
@@ -7,9 +7,9 @@ def main() -> None:
     """
 
     args = parse_args()
-
+    print(f"Debug mode: {args.debug}")
     from sketchlogic.controller import run
-    run(args.input_image_path, args.output_json_path)
+    run(args.input_image_path, args.output_json_path, args.debug)
 
 
 if __name__ == "__main__":

--- a/sketchlogic/controller.py
+++ b/sketchlogic/controller.py
@@ -2,21 +2,22 @@ from pathlib import Path
 import sketchlogic.model.controller
 import sketchlogic.connector.controller
 import sketchlogic.converter.controller
+from sketchlogic.parser import parse_args
 import json
 
 
-def run(input_image_path: Path, output_json_path: Path) -> None:
+def run(input_image_path: Path, output_json_path: Path, debug: bool = False) -> None:
     """
     Controller for the sketchlogic system.
     """
 
-    model_results, next_id = sketchlogic.model.controller.run(input_image_path, debug=True)
+    model_results, next_id = sketchlogic.model.controller.run(input_image_path, debug=debug)
 
     model_results, wires, io_results, next_id = sketchlogic.connector.controller.run(
-        input_image_path, model_results, next_id, debug=True
+        input_image_path, model_results, next_id, debug=debug
     )
 
-    output = sketchlogic.converter.controller.run(model_results, wires, io_results, debug=True)
+    output = sketchlogic.converter.controller.run(model_results, wires, io_results, debug=debug)
 
     with open(output_json_path, "w") as file:
         json.dump(output, file, indent=4)

--- a/sketchlogic/controller.py
+++ b/sketchlogic/controller.py
@@ -2,7 +2,6 @@ from pathlib import Path
 import sketchlogic.model.controller
 import sketchlogic.connector.controller
 import sketchlogic.converter.controller
-from sketchlogic.parser import parse_args
 import json
 
 


### PR DESCRIPTION
This PR lets user choose if they want to see the debug output in terminal through `--debug` flag. 

## Resolves
Resolves #56 

# Terminal output- 
## With Debug
###  `python -m sketchlogic temp.jpg  output.iris --debug` 
<img width="1451" height="725" alt="image" src="https://github.com/user-attachments/assets/118767ae-f1e2-4a4b-94c0-7faa9c36057f" />


## Without Debug
### `python -m sketchlogic temp.jpg  output.iris` 
<img width="1463" height="176" alt="image" src="https://github.com/user-attachments/assets/3c156288-b1cf-44c7-acaa-8c9720a8f488" />



Please review the PR and add suggestion for improvement i will try my best to resolve

Thanks a lot